### PR TITLE
Pull improvements from original libwrapper code

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -68,16 +68,22 @@ Hooks.once('init', () => {
 	if(WARN_FALLBACK) {
 		//************** USER CUSTOMIZABLE:
 		// Module ID - by default attempts to auto-detect, but you might want to hardcode your module ID here to avoid potential auto-detect issues
-		const MODULE_ID = ((import.meta?.url ?? Error().stack)?.match(/(?<=\/)modules\/.+(?=\/)/i)??[])[0]?.split('/')?.find(n => n && game.modules.has(n));
-		if(!MODULE_ID) {
-			console.error("libWrapper Shim: Could not auto-detect module ID. The libWrapper fallback warning dialog will be disabled.");
-			return;
-		}
+                const [MODULE_ID, MODULE_TITLE] = (()=>{
+                        const match = (import.meta?.url ?? Error().stack)?.match(/\/(worlds|systems|>
+                        if(match?.length !== 3) return [null,null];
+                        const dirs = match[2].split('/');
+                        if(match[1] === 'worlds') return dirs.find(n => n && game.world.id === n) ? >
+                        if(match[1] === 'systems') return dirs.find(n => n && game.system.id === n) >
+                        const id = dirs.find(n => n && game.modules.has(n));
+                        return [id, game.modules.get(id)?.data?.title];
+                })();
+
+                if(!MODULE_ID || !MODULE_TITLE) {
+                        console.error("libWrapper Shim: Could not auto-detect module ID and/or title>
+                        return;
+                }
 
 		Hooks.once('ready', () => {
-			// Module title
-			const MODULE_TITLE = game.modules.get(MODULE_ID).data.title;
-
 			//************** USER CUSTOMIZABLE:
 			// Title and message for the dialog shown when the real libWrapper is not installed.
 			const FALLBACK_MESSAGE_TITLE = MODULE_TITLE;


### PR DESCRIPTION
LibWrapper was recently updated with some improved checks to the shim. See https://github.com/ruipin/fvtt-lib-wrapper/blob/master/shim/shim.js.
These improvements include: (1) better checks for module id and title and (2) avoidance of positive lookbehind in regex, to resolve ruipin/fvtt-lib-wrapper#34.